### PR TITLE
Bug fixes and multiregion support

### DIFF
--- a/library/TeslaAccountRegion.cs
+++ b/library/TeslaAccountRegion.cs
@@ -1,0 +1,14 @@
+﻿
+namespace TeslaAuth
+{
+    /// <summary>
+    /// Tesla accounts are tied to SSO servers in particular regions.
+    /// </summary>
+    /// <remarks>It is not clear how many regions Tesla supports.  As of Feb 2021, it appears to be China vs. the rest of the world.</remarks>
+    public enum TeslaAccountRegion
+    {
+        Unknown,
+        USA,
+        China
+    }
+}

--- a/library/Tokens.cs
+++ b/library/Tokens.cs
@@ -1,9 +1,13 @@
+using System;
+
 namespace TeslaAuth
 {
 
     public class Tokens
     {
         public string AccessToken { get; set; }
-        public string RefreshToken {get; set; }
+        public string RefreshToken { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public TimeSpan ExpiresIn { get; set; }
     }
 }

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -14,13 +14,13 @@ namespace test
             Console.Write("MFA: ");
             string mfaCode = Console.ReadLine();
             TeslaAccountRegion region = TeslaAccountRegion.Unknown;
-            var tokens = TeslaAuthHelper.Authenticate(username, password, mfaCode, region);
+            var tokens = TeslaAuthHelper.AuthenticateAsync(username, password, mfaCode, region).Result;
             Console.WriteLine("Access token: " + tokens.AccessToken);
             Console.WriteLine("Refresh token: " + tokens.RefreshToken);
             Console.WriteLine("Created at: " + tokens.CreatedAt);
             Console.WriteLine("Expires in: " + tokens.ExpiresIn);
 
-            var newToken = TeslaAuthHelper.RefreshToken(tokens.RefreshToken, region);
+            var newToken = TeslaAuthHelper.RefreshTokenAsync(tokens.RefreshToken, region).Result;
             Console.WriteLine("Refreshed Access token: " + newToken.AccessToken);
             Console.WriteLine("New Refresh token: " + newToken.RefreshToken);
             Console.WriteLine("Refreshed token created at: " + newToken.CreatedAt);

--- a/test/Program.cs
+++ b/test/Program.cs
@@ -11,14 +11,20 @@ namespace test
             string username = Console.ReadLine();
             Console.Write("Password: ");
             string password = Console.ReadLine();
-            Console.Write("MFA: "); 
+            Console.Write("MFA: ");
             string mfaCode = Console.ReadLine();
-            var tokens = TeslaAuthHelper.Authenticate(username, password, mfaCode);
+            TeslaAccountRegion region = TeslaAccountRegion.Unknown;
+            var tokens = TeslaAuthHelper.Authenticate(username, password, mfaCode, region);
             Console.WriteLine("Access token: " + tokens.AccessToken);
             Console.WriteLine("Refresh token: " + tokens.RefreshToken);
+            Console.WriteLine("Created at: " + tokens.CreatedAt);
+            Console.WriteLine("Expires in: " + tokens.ExpiresIn);
 
-            var newToken = TeslaAuthHelper.RefreshToken(tokens.RefreshToken);
-            Console.WriteLine("Refreshed Access token: " + newToken);
+            var newToken = TeslaAuthHelper.RefreshToken(tokens.RefreshToken, region);
+            Console.WriteLine("Refreshed Access token: " + newToken.AccessToken);
+            Console.WriteLine("New Refresh token: " + newToken.RefreshToken);
+            Console.WriteLine("Refreshed token created at: " + newToken.CreatedAt);
+            Console.WriteLine("Refreshed token expires in: " + newToken.ExpiresIn);
         }
     }
 }

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Add a TeslaAccountRegion enum to handle China's separate Tesla SSO server.
(I can't test this in China, but the steps are in line with Tim Dorr's current documentation for the new authorization process.)
We should track when tokens are created, and when they expire.
Random is not threadsafe.
Removed two unnecessary collection objects in InitializeLogin.
Upgraded test to .NET 5.