### PR TITLE
Step 4 JWT Bearer Token no longer working.

### DIFF
--- a/library/TeslaAuth.csproj
+++ b/library/TeslaAuth.csproj
@@ -28,6 +28,6 @@ Requires using a WebView or similar integrated browser to show the Tesla login U
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi Tom, as per https://github.com/timdorr/tesla-api/issues/548, Step 4 of the authentication sequence https://tesla-api.timdorr.com/api-basics/authentication (exchange bearer token for JWT access token) is no longer required (and, more to the point, fails).

This pull request comments out the calls to step 4, with the necessary changes to return equivalent tokens (with the same four class members).

There is a potentially unnecessary change included in this pull request - updating the Newtonsoft package reference to 13.0.1 - I had to do this to get this to work in my app; feel free to reject this request if you'd like me to re-submit with only the necessary change.